### PR TITLE
Update CVE-2022-30470.md

### DIFF
--- a/filerun/CVE-2022-30470.md
+++ b/filerun/CVE-2022-30470.md
@@ -19,7 +19,7 @@
 The application allows the usage of Apache Tika to extract file contents.
 The path of the jar file can be configured in the web interface as superuser.
 
-A user can upload any custom jar file to receive remote code execution.
+The FileRun superuser can upload any custom jar file to receive remote code execution.
 
 
 ## Proof of Concept


### PR DESCRIPTION
The FileRun superuser is assumed to have control over the server. I don't think this is an issue, unless any other FileRun user can do this. Which doesn't seem possible.